### PR TITLE
Import annotations to use union operator in earlier python versions.

### DIFF
--- a/tcmb/utils.py
+++ b/tcmb/utils.py
@@ -1,4 +1,6 @@
 """Utilities module."""
+from __future__ import annotations
+
 import json
 import re
 import os.path


### PR DESCRIPTION
Add `from __future__ import annotations` to make Union operator available for the older versions of Python. Fixes #14.