### PR TITLE
Bugfix/15 fix column dtype conversion

### DIFF
--- a/tcmb/auth.py
+++ b/tcmb/auth.py
@@ -33,7 +33,9 @@ def check_status(response):
             # Therefore the traceback is printed as well as the most
             # probable cause of the HTTPError: ApiKeyError
             print(err.with_traceback(None))
-            raise ApiKeyError("API key is invalid.") from err
+            raise ApiKeyError(
+                "API key is invalid or wrong key. See error message for details."
+            ) from err
     else:
         try:
             response.json()

--- a/tcmb/core.py
+++ b/tcmb/core.py
@@ -122,7 +122,9 @@ def read(
     # convert list to str seperated by "-"
     # as descibed in the api reference
     if isinstance(series, list):
-        series = "-".join(series)
+        series_str = "-".join(series)
+    else:
+        series_str = series
 
     # convert list to str seperated by "-"
     if isinstance(agg, list):
@@ -135,7 +137,7 @@ def read(
         end = utils.standardize_date(end)
 
     params = {
-        "series": series,
+        "series": series_str,
         "startDate": start or "01-01-1970",
         "endDate": end or date.today().strftime("%d-%m-%Y"),
         "type": "json",  # csv, xml, json
@@ -156,7 +158,7 @@ def read(
 
     # convert response JSON to DataFrame
     #   time series data is in the "items"
-    data = utils.to_dataframe(res.json()["items"])
+    data = utils.to_dataframe(res.json()["items"], series=series)
 
     return data
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+from tcmb import utils
+
+import pytest
+
+
+test_date_data = [
+    ("01-01-2024", "01-01-2024"),
+    ("17.12.2009", "17-12-2009"),
+    ("2011-06-18", "18-06-2011"),
+    ("2018.04.10", "10-04-2018"),
+]
+
+
+@pytest.mark.parametrize("date_str, expected", test_date_data)
+def test_standardize_date(date_str, expected):
+    result = utils.standardize_date(date_str)
+    print(result)
+    assert result == expected
+
+
+def test_wildcard_search():
+    items_expected = [
+        "TP.API.REP.TL.A12",
+        "TP.API.REP.TL.A23",
+        "TP.API.REP.TL.G1",
+        "TP.API.REP.TL.G1530",
+        "TP.API.REP.TL.G214",
+    ]
+    items = utils.wildcard_search("TP.API.REP.TL.*")
+
+    assert all(item in items_expected for item in items)


### PR DESCRIPTION
Fix #15 , where the columns cannot be converted to numeric, because there are non-value attributes (`YEARWEEK` in the case of `'TP.KTFTUK' series) in the json response. In many cases, all the columns are value columns; however, there seems to be cases where this doesn't work.

`utils.to_dataframe()` function is updated to select value columns using the series keys passed by the user. Replacing `.` in the series keys with `_` help to find out value columns.